### PR TITLE
Fix infinite loops, and packet loss.

### DIFF
--- a/Adafruit_BluefruitLE_SPI.cpp
+++ b/Adafruit_BluefruitLE_SPI.cpp
@@ -562,17 +562,17 @@ bool Adafruit_BluefruitLE_SPI::getPacket(sdepMsgResponse_t* p_response)
       delayMicroseconds(SPI_DEFAULT_DELAY_US);
       SPI_CS_ENABLE();
     } else if (p_header->msg_type == SPI_OVERREAD_BYTE) {
-          Serial.printf("over read byte!\r\n");
+//          Serial.printf("over read byte!\r\n");
       SPI_CS_DISABLE();
       // wait for the clock to be enabled..
       while (!digitalRead(m_irq_pin)) {
-            Serial.printf("wait on IRQ pin: %d\r\n", millis());
+//            Serial.printf("wait on IRQ pin: %d\r\n", millis());
         if (tt.expired()) {
           break;
         }
       }
       if (!digitalRead(m_irq_pin)) {
-            Serial.println("data not ready!");
+//            Serial.println("data not ready!");
         break;
       }
       SPI_CS_ENABLE();

--- a/Adafruit_BluefruitLE_SPI.h
+++ b/Adafruit_BluefruitLE_SPI.h
@@ -40,9 +40,6 @@
 #include <SPI.h>
 #include "utility/Adafruit_FIFO.h"
 
-#define SPI_CS_ENABLE()           digitalWrite(m_cs_pin, LOW)
-#define SPI_CS_DISABLE()          digitalWrite(m_cs_pin, HIGH)
-
 #define SPI_IGNORED_BYTE          0xFEu /**< SPI default character. Character clocked out in case of an ignored transaction. */
 #define SPI_OVERREAD_BYTE         0xFFu /**< SPI over-read character. Character clocked out after an over-read of the transmit buffer. */
 #define SPI_DEFAULT_DELAY_US      50


### PR DESCRIPTION
Hi! I noticed several problems when using the library. I will sometimes see the library getting into infinite loops and also loosing packets. It took me a while, but I realized what the problems are (I'll also post on the Adafruit forums soon). I forked and fixed them with minimal changes in https://github.com/corbinstreehouse/Adafruit_BluefruitLE_nRF51, I also have re-write branch that does it better.

Conceptually, here are the issues:

Adafruit_BluefruitLE_SPI::getResponse has this while loop: while ( digitalRead(m_irq_pin) && m_rx_fifo.remaining() >= SDEP_MAX_PACKETSIZE )
The problem here is the irq pin might still be left pulled, but data isn't available..this causes problems in getPacket, where it reads the header based on it not reading SPI_IGNORED_BYTE. However, it will eventually get a non-ignored byte from the last packet, and the code:

while ( p_header->msg_type != SDEP_MSGTYPE_RESPONSE && p_header->msg_type != SDEP_MSGTYPE_ERROR )
{
  p_header->msg_type = spixfer(0xff);
}
will skip over bytes loosing data. This is the cause of packet loss.

getPacket needs to be rewritten to do the IRQ assertion test at its start. However, I find that on a fast processor (teensy 3.1) it will still be asserted from the last packet. This causes the header to get SPI_OVERREAD_BYTE. If we get SPI_OVERREAD_BYTE , we should wait more on the m_irq_pin.

You don't have to take these changes...but they will be here for other people who have the same problems. I would also delete this hacky part that I left in (although, I added a check on the timeout to avoid infinite loops that I was seeing):

```
while ( p_header->msg_type != SDEP_MSGTYPE_RESPONSE && p_header->msg_type != SDEP_MSGTYPE_ERROR )
{
  p_header->msg_type = spixfer(0xff);
  // Also check the timeout..
  if ( tt.expired() ) break;
}
```

Without my changes, I was seeing the code get into an finite loop when I send a 1k file over the UART transmit characteristic from the central. When it did work (usually because I put logs in, which changed the timing of the IRQ assertion), I would see packet loss due to  what I described above. 

With my changes, I can send a 1kb file in 9.5 seconds. Horribly slow! 
