### PR TITLE
Added methods for checking the FIFO buffer

### DIFF
--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -487,6 +487,32 @@ bool Adafruit_BLE::readNVM(uint16_t offset, int32_t* number)
 
 /******************************************************************************/
 /*!
+    @brief Check the remaining space in the Rx Fifo buffer
+    @param
+*/
+/******************************************************************************/
+uint16_t Adafruit_BLE::remainingFifoRxBuffer()
+{
+  int32_t remainingBuffer = 0;
+  atcommandIntReply(F("AT+BLEUARTFIFO=RX"), &remainingBuffer);
+  return remainingBuffer;
+}
+
+/******************************************************************************/
+/*!
+	@brief Check the remaining space in the Tx Fifo buffer
+    @param
+*/
+/******************************************************************************/
+uint16_t Adafruit_BLE::remainingFifoTxBuffer()
+{
+  int32_t remainingBuffer = 0;
+  atcommandIntReply(F("AT+BLEUARTFIFO=TX"), &remainingBuffer);
+  return remainingBuffer;
+}
+
+/******************************************************************************/
+/*!
     @brief  Set handle for connect callback
 
     @param[in] fp function pointer, NULL will discard callback

--- a/Adafruit_BLE.h
+++ b/Adafruit_BLE.h
@@ -107,6 +107,8 @@ class Adafruit_BLE : public Adafruit_ATParser
     bool readNVM(uint16_t offset, char  * str   , uint16_t size);
     bool readNVM(uint16_t offset, int32_t* number);
 
+	uint16_t remainingFifoRxBuffer();
+	uint16_t remainingFifoTxBuffer();
 
     // No parameters
     bool sendCommandCheckOK(const __FlashStringHelper *cmd) { return this->atcommand(cmd); }


### PR DESCRIPTION
I added a few convenience methods for checking the remaining FIFO buffer.
I've a use case where extremely low latency is more important than making sure every packet is sent, 
so I found myself needing to check make sure that there's enough room in the buffer to ensure I don't pay the 200ms penalty for over-running it, as described [here](https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le/ble-services#at-plus-bleuarttx).

The change is just a wrapper around the [AT+BLEUARTFIFO command](https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le/ble-services#at-plus-bleuartfifo). I'm not a fan of using strings when I can wrap a command like this with code. There are other implementations of AT commands in the 
Adafruit_BLE class, so it seemed to fit in there.
