### PR TITLE
Context aware callback methods.

### DIFF
--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -81,9 +81,6 @@ Adafruit_BLE::Adafruit_BLE(void)
 /******************************************************************************/
 void Adafruit_BLE::install_callback(bool enable, int8_t system_id, int8_t gatts_id)
 {
-  bool v = _verbose;
-  _verbose = true;
-
   uint8_t current_mode = _mode;
 
   // switch mode if necessary to execute command
@@ -104,8 +101,6 @@ void Adafruit_BLE::install_callback(bool enable, int8_t system_id, int8_t gatts_
 
   // switch back if necessary
   if ( current_mode == BLUEFRUIT_MODE_DATA ) setMode(BLUEFRUIT_MODE_DATA);
-
-  _verbose = v;
 }
 
 /******************************************************************************/

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -743,11 +743,35 @@ void Adafruit_BLE::setBleGattRxCallback(int32_t chars_idx,  void (*fp) (int32_t,
     @param[in] fp function pointer, NULL will discard callback
 */
 /******************************************************************************/
-void Adafruit_BLE::setBleGattRxCallback(int32_t chars_idx,  void (*fp) (void*, int32_t, uint8_t[], uint16_t) )
+void Adafruit_BLE::setBleGattRxCallback(void (*fp) (void*, int32_t, uint8_t[], uint16_t) )
 {
-  if ( chars_idx == 0) return;
-
   this->_ble_gatt_rx_callback_context = fp;
-  install_callback(fp != NULL, -1, chars_idx-1);
 }
 
+/******************************************************************************/
+/*!
+    @brief  Enables a GATT an attribute for callback.
+    
+    @param[in] The attribute to receive callbacks for.
+*/
+/******************************************************************************/
+void Adafruit_BLE::enableBleGattCallback(int32_t chars_idx)
+{
+  if ( chars_idx == 0 ) return;
+
+  install_callback(true, -1, chars_idx-1);
+}
+
+/******************************************************************************/
+/*!
+    @brief  Enables a GATT an attribute for callback.
+    
+    @param[in] The attribute to receive callbacks for.
+*/
+/******************************************************************************/
+void Adafruit_BLE::disableBleGattCallback(int32_t chars_idx)
+{
+  if ( chars_idx == 0 ) return;
+
+  install_callback(false, -1, chars_idx-1);
+}

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -592,6 +592,8 @@ void Adafruit_BLE::setCallbackContext(void* context) {
     @brief  Set handle for connect callback
 
     @param[in] fp function pointer, NULL will discard callback
+    
+    @deprecated
 */
 /******************************************************************************/
 void Adafruit_BLE::setConnectCallback( void (*fp) (void) )
@@ -618,6 +620,8 @@ void Adafruit_BLE::setConnectCallback( void (*fp) (void* context) )
     @brief  Set handle for disconnection callback
 
     @param[in] fp function pointer, NULL will discard callback
+    
+    @deprecated
 */
 /******************************************************************************/
 void Adafruit_BLE::setDisconnectCallback( void (*fp) (void) )
@@ -644,6 +648,8 @@ void Adafruit_BLE::setDisconnectCallback( void (*fp) (void* context) )
     @brief  Set handle for BLE Uart Rx callback
 
     @param[in] fp function pointer, NULL will discard callback
+    
+    @deprecated
 */
 /******************************************************************************/
 void Adafruit_BLE::setBleUartRxCallback( void (*fp) (char data[], uint16_t len) )

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -71,6 +71,11 @@ Adafruit_BLE::Adafruit_BLE(void)
   _ble_uart_rx_callback = NULL;
   _ble_midi_rx_callback = NULL;
   _ble_gatt_rx_callback = NULL;
+  
+  _disconnect_callback_context  = NULL;
+  _connect_callback_context     = NULL;
+  _ble_uart_rx_callback_context = NULL;
+  _callback_context             = NULL;
 }
 
 /******************************************************************************/
@@ -550,6 +555,17 @@ int  Adafruit_BLE::readBLEUart(uint8_t* buffer, int size)
 
 /******************************************************************************/
 /*!
+    @brief  Set the context for all context aware callbacks.
+
+    @param[in] context pointer, NULL will discard callback
+*/
+/******************************************************************************/
+void Adafruit_BLE::setCallbackContext(void* context) {
+    this->_callback_context = context;
+}
+
+/******************************************************************************/
+/*!
     @brief  Set handle for connect callback
 
     @param[in] fp function pointer, NULL will discard callback
@@ -558,6 +574,19 @@ int  Adafruit_BLE::readBLEUart(uint8_t* buffer, int size)
 void Adafruit_BLE::setConnectCallback( void (*fp) (void) )
 {
   this->_connect_callback = fp;
+  install_callback(fp != NULL, EVENT_SYSTEM_CONNECT, -1);
+}
+
+/******************************************************************************/
+/*!
+    @brief  Set handle for connect callback with a context.
+
+    @param[in] fp function pointer, NULL will discard callback
+*/
+/******************************************************************************/
+void Adafruit_BLE::setConnectCallback( void (*fp) (void* context) )
+{
+  this->_connect_callback_context = fp;
   install_callback(fp != NULL, EVENT_SYSTEM_CONNECT, -1);
 }
 
@@ -576,6 +605,19 @@ void Adafruit_BLE::setDisconnectCallback( void (*fp) (void) )
 
 /******************************************************************************/
 /*!
+    @brief  Set handle for disconnection callback with a context
+
+    @param[in] fp function pointer, NULL will discard callback
+*/
+/******************************************************************************/
+void Adafruit_BLE::setDisconnectCallback( void (*fp) (void* context) )
+{
+  this->_disconnect_callback_context = fp;
+  install_callback(fp != NULL, EVENT_SYSTEM_DISCONNECT, -1);
+}
+
+/******************************************************************************/
+/*!
     @brief  Set handle for BLE Uart Rx callback
 
     @param[in] fp function pointer, NULL will discard callback
@@ -584,6 +626,19 @@ void Adafruit_BLE::setDisconnectCallback( void (*fp) (void) )
 void Adafruit_BLE::setBleUartRxCallback( void (*fp) (char data[], uint16_t len) )
 {
   this->_ble_uart_rx_callback = fp;
+  install_callback(fp != NULL, EVENT_SYSTEM_BLE_UART_RX, -1);
+}
+
+/******************************************************************************/
+/*!
+    @brief  Set handle for BLE Uart Rx callback
+
+    @param[in] fp function pointer, NULL will discard callback
+*/
+/******************************************************************************/
+void Adafruit_BLE::setBleUartRxCallback( void (*fp) (void* context, char data[], uint16_t len) )
+{
+  this->_ble_uart_rx_callback_context = fp;
   install_callback(fp != NULL, EVENT_SYSTEM_BLE_UART_RX, -1);
 }
 

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -319,10 +319,6 @@ void Adafruit_BLE::update(uint32_t period_ms)
 
     //--------------------------------------------------------------------+
     // System Event
-    //
-    // Converted this system_event section to use "else if" blocks instead of
-    // if. That way checks wont be made as only one system event can happen 
-    // per update cycle.
     //--------------------------------------------------------------------+
     if ( bitRead( system_event, EVENT_SYSTEM_CONNECT ) ) 
     {
@@ -331,7 +327,8 @@ void Adafruit_BLE::update(uint32_t period_ms)
         else if( this->_connect_callback )
             this->_connect_callback();
     }
-    else if ( bitRead( system_event, EVENT_SYSTEM_DISCONNECT ) ) 
+      
+    if ( bitRead( system_event, EVENT_SYSTEM_DISCONNECT ) ) 
     {
         if( this->_disconnect_callback_context )
             this->_disconnect_callback_context(this->_callback_context);
@@ -339,9 +336,8 @@ void Adafruit_BLE::update(uint32_t period_ms)
             this->_disconnect_callback();
     }
     // Double checking for NULL, minor decrease in performance but will have to stay until non-context based
-    // Methods are removed. Converting to "else if" blocks should increase performance so hopefully makes up
-    // for the performance loss in the double check.
-    else if ( ( this->_ble_uart_rx_callback_context || this->_ble_uart_rx_callback ) && 
+    // Methods are removed.
+    if ( ( this->_ble_uart_rx_callback_context || this->_ble_uart_rx_callback ) && 
               ( bitRead(system_event, EVENT_SYSTEM_BLE_UART_RX) ) )
     {
       // _verbose = true;
@@ -355,7 +351,8 @@ void Adafruit_BLE::update(uint32_t period_ms)
       else if ( this->_ble_uart_rx_callback )
           this->_ble_uart_rx_callback( (char*) tempbuf, len );
     }
-    else if ( this->_ble_midi_rx_callback && bitRead(system_event, EVENT_SYSTEM_BLE_MIDI_RX) )
+    
+    if ( this->_ble_midi_rx_callback && bitRead(system_event, EVENT_SYSTEM_BLE_MIDI_RX) )
     {
 //      _verbose = true;
       while(1)

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -319,8 +319,12 @@ void Adafruit_BLE::update(uint32_t period_ms)
 
     //--------------------------------------------------------------------+
     // System Event
+    //
+    // Double checking for NULL, minor decrease in performance but will have 
+    // to stay until non-context based Methods are removed.
     //--------------------------------------------------------------------+
-    if ( bitRead( system_event, EVENT_SYSTEM_CONNECT ) ) 
+    if ( ( this->_connect_callback_context || this->_connect_callback ) && 
+         ( bitRead( system_event, EVENT_SYSTEM_CONNECT ) ) ) 
     {
         if( this->_connect_callback_context )
             this->_connect_callback_context(this->_callback_context);
@@ -328,15 +332,15 @@ void Adafruit_BLE::update(uint32_t period_ms)
             this->_connect_callback();
     }
       
-    if ( bitRead( system_event, EVENT_SYSTEM_DISCONNECT ) ) 
+    if ( ( this->_disconnect_callback_context || this->_disconnect_callback ) && 
+         ( bitRead( system_event, EVENT_SYSTEM_DISCONNECT) ) ) 
     {
         if( this->_disconnect_callback_context )
             this->_disconnect_callback_context(this->_callback_context);
         else if( this->_disconnect_callback )
             this->_disconnect_callback();
     }
-    // Double checking for NULL, minor decrease in performance but will have to stay until non-context based
-    // Methods are removed.
+    
     if ( ( this->_ble_uart_rx_callback_context || this->_ble_uart_rx_callback ) && 
               ( bitRead(system_event, EVENT_SYSTEM_BLE_UART_RX) ) )
     {

--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -324,6 +324,9 @@ void Adafruit_BLE::update(uint32_t period_ms)
     // Double checking for NULL, minor decrease in performance but will have 
     // to stay until non-context based Methods are removed.
     //--------------------------------------------------------------------+
+    //--------------------------------------------------------------------+
+    // Connect Event
+    //--------------------------------------------------------------------+
     if ( ( this->_connect_callback_context || this->_connect_callback ) && 
          ( bitRead( system_event, EVENT_SYSTEM_CONNECT ) ) ) 
     {
@@ -332,7 +335,10 @@ void Adafruit_BLE::update(uint32_t period_ms)
         else
             this->_connect_callback();
     }
-      
+    
+    //--------------------------------------------------------------------+
+    // Disconnect Event
+    //--------------------------------------------------------------------+
     if ( ( this->_disconnect_callback_context || this->_disconnect_callback ) && 
          ( bitRead( system_event, EVENT_SYSTEM_DISCONNECT) ) ) 
     {
@@ -342,6 +348,9 @@ void Adafruit_BLE::update(uint32_t period_ms)
             this->_disconnect_callback();
     }
     
+    //--------------------------------------------------------------------+
+    // UART Event
+    //--------------------------------------------------------------------+
     if ( ( this->_ble_uart_rx_callback_context || this->_ble_uart_rx_callback ) && 
               ( bitRead(system_event, EVENT_SYSTEM_BLE_UART_RX) ) )
     {
@@ -356,6 +365,9 @@ void Adafruit_BLE::update(uint32_t period_ms)
           this->_ble_uart_rx_callback( (char*) tempbuf, len );
     }
     
+    //--------------------------------------------------------------------+
+    // MIDI Event
+    //--------------------------------------------------------------------+
     if ( ( this->_ble_midi_rx_callback ||  this->_ble_midi_rx_callback_context ) && 
            bitRead(system_event, EVENT_SYSTEM_BLE_MIDI_RX) )
     {

--- a/Adafruit_BLE.h
+++ b/Adafruit_BLE.h
@@ -73,8 +73,9 @@ class Adafruit_BLE : public Adafruit_ATParser
     uint32_t _reset_started_timestamp;
 
   public:
-    typedef void (*midiRxCallback_t) (uint16_t timestamp, uint8_t status, uint8_t byte1, uint8_t byte2);
-
+    typedef void (*midiRxCallback_t)        (uint16_t timestamp, uint8_t status, uint8_t byte1, uint8_t byte2);
+    typedef void (*midiRxCallbackContext_t) (void *context, uint16_t timestamp, uint8_t status, uint8_t byte1, uint8_t byte2);
+    
     // Constructor
     Adafruit_BLE(void);
 
@@ -132,27 +133,36 @@ class Adafruit_BLE : public Adafruit_ATParser
       this->update(0);
     }
 
+    // ---------------------------------------------------------------------------
+    // Deprecate these and remove in future releases.
     void setDisconnectCallback( void (*fp) (void) );
     void setConnectCallback   ( void (*fp) (void) );
     void setBleUartRxCallback( void (*fp) (char data[], uint16_t len) );
     void setBleMidiRxCallback( midiRxCallback_t fp );
     void setBleGattRxCallback( int32_t chars_idx, void (*fp) (int32_t, uint8_t[], uint16_t) );
+    // ----------------------------------------------------------------------------
     
     // Updated callback methods to handle a callback context.
     void setDisconnectCallback( void (*fp) (void* context) );
     void setConnectCallback   ( void (*fp) (void* context) );
     void setBleUartRxCallback ( void (*fp) (void* context, char data[], uint16_t len) );
     void setBleGattRxCallback ( int32_t chars_idx, void (*fp) (void*, int32_t, uint8_t[], uint16_t) );
+    void setBleMidiRxCallback ( midiRxCallbackContext_t fp );
     void setCallbackContext   ( void* context );
     
   protected:
     // helper
     void install_callback(bool enable, int8_t system_id, int8_t gatts_id);
 
+    // ---------------------------------------------------------------------------
+    // Deprecate these and remove in future releases.
     void (*_disconnect_callback) (void);
     void (*_connect_callback) (void);
     void (*_ble_uart_rx_callback) (char data[], uint16_t len);
     void (*_ble_gatt_rx_callback) (int32_t chars_id, uint8_t data[], uint16_t len);
+    // ----------------------------------------------------------------------------
+    
+    midiRxCallback_t _ble_midi_rx_callback;
     
     // Updated callback methods to handle a callback context.
     void (*_disconnect_callback_context)  (void* context);
@@ -161,9 +171,7 @@ class Adafruit_BLE : public Adafruit_ATParser
     void (*_ble_gatt_rx_callback_context) (void* context, int32_t chars_id, uint8_t data[], uint16_t len);
     void *_callback_context;
     
-    midiRxCallback_t _ble_midi_rx_callback;
-
-    
+    midiRxCallbackContext_t _ble_midi_rx_callback_context;
 };
 
 //--------------------------------------------------------------------+

--- a/Adafruit_BLE.h
+++ b/Adafruit_BLE.h
@@ -138,7 +138,13 @@ class Adafruit_BLE : public Adafruit_ATParser
     void setBleUartRxCallback( void (*fp) (char data[], uint16_t len) );
     void setBleMidiRxCallback( midiRxCallback_t fp );
     void setBleGattRxCallback( int32_t chars_idx, void (*fp) (int32_t, uint8_t[], uint16_t) );
-
+    
+    // Updated callback methods to handle a callback context.
+    void setDisconnectCallback( void (*fp) (void* context) );
+    void setConnectCallback   ( void (*fp) (void* context) );
+    void setBleUartRxCallback ( void (*fp) (void* context, char data[], uint16_t len) );
+    void setCallbackContext   ( void* context );
+    
   protected:
     // helper
     void install_callback(bool enable, int8_t system_id, int8_t gatts_id);
@@ -147,6 +153,13 @@ class Adafruit_BLE : public Adafruit_ATParser
     void (*_connect_callback) (void);
 
     void (*_ble_uart_rx_callback) (char data[], uint16_t len);
+    
+    // Updated callback methods to handle a callback context.
+    void (*_disconnect_callback_context)  (void* context);
+    void (*_connect_callback_context)     (void* context);
+    void (*_ble_uart_rx_callback_context) (void* context, char data[], uint16_t len);
+    void *_callback_context;
+    
     midiRxCallback_t _ble_midi_rx_callback;
 
     void (*_ble_gatt_rx_callback) (int32_t chars_id, uint8_t data[], uint16_t len);

--- a/Adafruit_BLE.h
+++ b/Adafruit_BLE.h
@@ -143,12 +143,14 @@ class Adafruit_BLE : public Adafruit_ATParser
     // ----------------------------------------------------------------------------
     
     // Updated callback methods to handle a callback context.
-    void setDisconnectCallback( void (*fp) (void* context) );
-    void setConnectCallback   ( void (*fp) (void* context) );
-    void setBleUartRxCallback ( void (*fp) (void* context, char data[], uint16_t len) );
-    void setBleGattRxCallback ( int32_t chars_idx, void (*fp) (void*, int32_t, uint8_t[], uint16_t) );
-    void setBleMidiRxCallback ( midiRxCallbackContext_t fp );
-    void setCallbackContext   ( void* context );
+    void setDisconnectCallback   ( void (*fp) (void* context) );
+    void setConnectCallback      ( void (*fp) (void* context) );
+    void setBleUartRxCallback    ( void (*fp) (void* context, char data[], uint16_t len) );
+    void setBleGattRxCallback    ( void (*fp) (void*, int32_t, uint8_t[], uint16_t) );
+    void enableBleGattCallback   ( int32_t chars_idx );
+    void disableBleGattCallback  ( int32_t chars_idx );
+    void setBleMidiRxCallback    ( midiRxCallbackContext_t fp );
+    void setCallbackContext      ( void* context );
     
   protected:
     // helper

--- a/Adafruit_BLE.h
+++ b/Adafruit_BLE.h
@@ -134,7 +134,6 @@ class Adafruit_BLE : public Adafruit_ATParser
 
     void setDisconnectCallback( void (*fp) (void) );
     void setConnectCallback   ( void (*fp) (void) );
-
     void setBleUartRxCallback( void (*fp) (char data[], uint16_t len) );
     void setBleMidiRxCallback( midiRxCallback_t fp );
     void setBleGattRxCallback( int32_t chars_idx, void (*fp) (int32_t, uint8_t[], uint16_t) );
@@ -143,6 +142,7 @@ class Adafruit_BLE : public Adafruit_ATParser
     void setDisconnectCallback( void (*fp) (void* context) );
     void setConnectCallback   ( void (*fp) (void* context) );
     void setBleUartRxCallback ( void (*fp) (void* context, char data[], uint16_t len) );
+    void setBleGattRxCallback ( int32_t chars_idx, void (*fp) (void*, int32_t, uint8_t[], uint16_t) );
     void setCallbackContext   ( void* context );
     
   protected:
@@ -151,18 +151,19 @@ class Adafruit_BLE : public Adafruit_ATParser
 
     void (*_disconnect_callback) (void);
     void (*_connect_callback) (void);
-
     void (*_ble_uart_rx_callback) (char data[], uint16_t len);
+    void (*_ble_gatt_rx_callback) (int32_t chars_id, uint8_t data[], uint16_t len);
     
     // Updated callback methods to handle a callback context.
     void (*_disconnect_callback_context)  (void* context);
     void (*_connect_callback_context)     (void* context);
     void (*_ble_uart_rx_callback_context) (void* context, char data[], uint16_t len);
+    void (*_ble_gatt_rx_callback_context) (void* context, int32_t chars_id, uint8_t data[], uint16_t len);
     void *_callback_context;
     
     midiRxCallback_t _ble_midi_rx_callback;
 
-    void (*_ble_gatt_rx_callback) (int32_t chars_id, uint8_t data[], uint16_t len);
+    
 };
 
 //--------------------------------------------------------------------+

--- a/Adafruit_BLEMIDI.cpp
+++ b/Adafruit_BLEMIDI.cpp
@@ -132,10 +132,10 @@ bool Adafruit_BLEMIDI::send_n(uint8_t status, const uint8_t bytes[], uint8_t cou
   return _ble.atcommand( F("AT+BLEMIDITX"), data, count+1);
 }
 
-static void Adafruit_BLEMIDI::_processRxCallback(uint8_t data[], uint16_t len, 
-                                                 Adafruit_BLE::midiRxCallback_t callback_func, 
-                                                 Adafruit_BLE::midiRxCallbackContext_t callbackcontext_func, 
-                                                 void* context) 
+void Adafruit_BLEMIDI::_processRxCallback(uint8_t data[], uint16_t len,
+                                          Adafruit_BLE::midiRxCallback_t callback_func,
+                                          Adafruit_BLE::midiRxCallbackContext_t callbackcontext_func,
+                                          void* context)
 {
   if ( len < 3 ) return;
 

--- a/Adafruit_BLEMIDI.cpp
+++ b/Adafruit_BLEMIDI.cpp
@@ -132,13 +132,10 @@ bool Adafruit_BLEMIDI::send_n(uint8_t status, const uint8_t bytes[], uint8_t cou
   return _ble.atcommand( F("AT+BLEMIDITX"), data, count+1);
 }
 
-/******************************************************************************/
-/*!
-    @brief
-    @param
-*/
-/******************************************************************************/
-void Adafruit_BLEMIDI::processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallback_t callback_func)
+static void Adafruit_BLEMIDI::_processRxCallback(uint8_t data[], uint16_t len, 
+                                                 Adafruit_BLE::midiRxCallback_t callback_func, 
+                                                 Adafruit_BLE::midiRxCallbackContext_t callbackcontext_func, 
+                                                 void* context) 
 {
   if ( len < 3 ) return;
 
@@ -165,22 +162,53 @@ void Adafruit_BLEMIDI::processRxCallback(uint8_t data[], uint16_t len, Adafruit_
 
       tstamp = (header.timestamp_hi << 7) | timestamp.timestamp_low;
       status = *data++;
-
+      
+      // Updated to use callback context.
       // Status must have 7th-bit set, must have something wrong
       if ( !bitRead(status, 7) ) return;
 
-      callback_func( tstamp, status, data[0], data[1]);
-
+      if ( callbackcontext_func )
+        callbackcontext_func( context, tstamp, status, data[0], data[1] );
+      else
+        callback_func( tstamp, status, data[0], data[1] );
+        
       len  -= 4;
       data += 2;
     }
     else
     {
+      // Updated to use callback context.
       // Running event
-      callback_func( tstamp, status, data[0], data[1]);
+      if ( callbackcontext_func )
+        callbackcontext_func( context, tstamp, status, data[0], data[1] );
+      else
+        callback_func( tstamp, status, data[0], data[1] );
 
       len  -= 2;
       data += 2;
     }
   }
+}
+
+/******************************************************************************/
+/*!
+    @brief Support for callback context.
+*/
+/******************************************************************************/
+void Adafruit_BLEMIDI::processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallbackContext_t callback_func, 
+                                         void* context)
+{
+  Adafruit_BLEMIDI::_processRxCallback(data, len, NULL, callback_func, context);
+}
+
+/******************************************************************************/
+/*!
+    @brief
+    @param
+    @deprecated
+*/
+/******************************************************************************/
+void Adafruit_BLEMIDI::processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallback_t callback_func)
+{
+  Adafruit_BLEMIDI::_processRxCallback(data, len, callback_func, NULL, NULL);
 }

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -75,7 +75,9 @@ private:
   Adafruit_BLE& _ble;
     
 protected:
-  static uint8_t _processRxCallback(uint8_t data[], uint16_t len, midi_rx_payload *payload);
+  static void _processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallback_t callback_func, 
+                                 Adafruit_BLE::midiRxCallbackContext_t callbackcontext_func, 
+                                 void* context);
 
 public:
   typedef Adafruit_BLE::midiRxCallback_t midiRxCallback_t;

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -85,7 +85,7 @@ private:
   Adafruit_BLE& _ble;
     
 protected:
-  static midi_rx_payload _processRxCallback(uint8_t data[], uint16_t len);
+  static uint8_t _processRxCallback(uint8_t data[], uint16_t len, midi_rx_payload *payload);
 
 public:
   typedef Adafruit_BLE::midiRxCallback_t midiRxCallback_t;

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -98,8 +98,11 @@ public:
   bool send_n(uint8_t status, const uint8_t bytes[], uint8_t count);
 
   void setRxCallback(midiRxCallback_t fp);
-
+  
+  // Deprecated.
   static void processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallback_t callback_func);
+    
+  static void processRxCallback(uint8_t data[], uint16_t len, Adafruit_BLE::midiRxCallbackContext_t callback_func, void* context);
 };
 
 #endif /* _ADAFRUIT_BLEMIDI_H_ */

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -69,6 +69,16 @@ typedef struct ATTR_PACKED
 
 ASSERT_STATIC_ ( sizeof(midi_timestamp_t) == 1 );
 
+/**
+ * @brief Structure to facillitate callback context.
+ */
+typedef struct {
+    uint16_t tstamp : 0;
+    uint8_t  status : 0;
+    uint8_t  byte1  : 0;
+    uint8_t  byte2  : 0;
+} midi_rx_payload;
+
 class Adafruit_BLEMIDI
 {
 private:

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -69,16 +69,6 @@ typedef struct ATTR_PACKED
 
 ASSERT_STATIC_ ( sizeof(midi_timestamp_t) == 1 );
 
-/**
- * @brief Structure to facillitate callback context.
- */
-typedef struct {
-    uint16_t tstamp : 0;
-    uint8_t  status : 0;
-    uint8_t  byte1  : 0;
-    uint8_t  byte2  : 0;
-} midi_rx_payload;
-
 class Adafruit_BLEMIDI
 {
 private:

--- a/Adafruit_BLEMIDI.h
+++ b/Adafruit_BLEMIDI.h
@@ -83,6 +83,9 @@ class Adafruit_BLEMIDI
 {
 private:
   Adafruit_BLE& _ble;
+    
+protected:
+  static midi_rx_payload _processRxCallback(uint8_t data[], uint16_t len);
 
 public:
   typedef Adafruit_BLE::midiRxCallback_t midiRxCallback_t;

--- a/Adafruit_BluefruitLE_UART.cpp
+++ b/Adafruit_BluefruitLE_UART.cpp
@@ -123,6 +123,10 @@ bool Adafruit_BluefruitLE_UART::begin(boolean debug, boolean blocking)
     pinMode(_cts_pin, OUTPUT);
     digitalWrite(_cts_pin, HIGH);  // turn off txo
   }
+    
+  if (_rts_pin > 0) {
+    pinMode(_rts_pin, INPUT);
+  }
 
   mySerial->setTimeout(_timeout);
   // reset Bluefruit module upon connect

--- a/Adafruit_BluefruitLE_UART.h
+++ b/Adafruit_BluefruitLE_UART.h
@@ -40,7 +40,7 @@
 #include "Arduino.h"
 #include <Adafruit_BLE.h>
 
-#define SOFTWARE_SERIAL_AVAILABLE   ( ! (defined (_VARIANT_ARDUINO_DUE_X_) || defined (_VARIANT_ARDUINO_ZERO_) || defined (ARDUINO_STM32_FEATHER)) )
+#define SOFTWARE_SERIAL_AVAILABLE   ( ! (defined (_VARIANT_ARDUINO_DUE_X_) || defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_STM32_FEATHER)) )
 
 #if SOFTWARE_SERIAL_AVAILABLE
   #include <SoftwareSerial.h>

--- a/changelog_firmware.md
+++ b/changelog_firmware.md
@@ -1,6 +1,6 @@
 # Firmware Changelog
 
-## 0.7.6
+## 0.7.7
 
 ### Features
 

--- a/changelog_firmware.md
+++ b/changelog_firmware.md
@@ -1,6 +1,6 @@
 # Firmware Changelog
 
-## 0.7.1
+## 0.7.6
 
 ### Features
 

--- a/examples/atcommand/atcommand.ino
+++ b/examples/atcommand/atcommand.ino
@@ -14,37 +14,37 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
 
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
 /*=========================================================================
     APPLICATION SETTINGS
 
-    FACTORYRESET_ENABLE     Perform a factory reset when running this sketch
-   
-                            Enabling this will put your Bluefruit LE module
+? ? FACTORYRESET_ENABLE? ?  Perform a factory reset when running this sketch
+? ?
+? ?                         Enabling this will put your Bluefruit LE module
                             in a 'known good' state and clear any config
                             data set in previous sketches or projects, so
-                            running this at least once is a good idea.
-   
-                            When deploying your project, however, you will
+? ?                         running this at least once is a good idea.
+? ?
+? ?                         When deploying your project, however, you will
                             want to disable factory reset by setting this
-                            value to 0.  If you are making changes to your
-                            Bluefruit LE device via AT commands, and those
+                            value to 0.? If you are making changes to your
+? ?                         Bluefruit LE device via AT commands, and those
                             changes aren't persisting across resets, this
-                            is the reason why.  Factory reset will erase
+                            is the reason why.? Factory reset will erase
                             the non-volatile memory where config data is
                             stored, setting it back to factory default
                             values.
-       
-                            Some sketches that require you to bond to a
+? ? ? ?
+? ?                         Some sketches that require you to bond to a
                             central device (HID mouse, keyboard, etc.)
                             won't work at all with this feature enabled
                             since the factory reset will clear all of the

--- a/examples/battery/battery.ino
+++ b/examples/battery/battery.ino
@@ -14,16 +14,17 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
 
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 #include "Adafruit_BLEBattery.h"
-
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/beacon/beacon.ino
+++ b/examples/beacon/beacon.ino
@@ -14,15 +14,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/bleuart_cmdmode/bleuart_cmdmode.ino
+++ b/examples/bleuart_cmdmode/bleuart_cmdmode.ino
@@ -14,15 +14,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/bleuart_datamode/bleuart_datamode.ino
+++ b/examples/bleuart_datamode/bleuart_datamode.ino
@@ -14,15 +14,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/callbacks/callbacks.ino
+++ b/examples/callbacks/callbacks.ino
@@ -14,15 +14,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /* This example demonstrates how to use Bluefruit callback API :
  * - setConnectCallback(), setDisconnectCallback(), setBleUartRxCallback(),

--- a/examples/callbacks_dfuirq/callbacks_dfuirq.ino
+++ b/examples/callbacks_dfuirq/callbacks_dfuirq.ino
@@ -14,16 +14,16 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-#include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 #include "Adafruit_BLEGatt.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /* This example demonstrates how to use Bluefruit callback API :
    - setConnectCallback(), setDisconnectCallback(), setBleUartRxCallback(),

--- a/examples/controller/controller.ino
+++ b/examples/controller/controller.ino
@@ -15,15 +15,15 @@
 #include <string.h>
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/cplay_neopixel_picker/cplay_neopixel_picker.ino
+++ b/examples/cplay_neopixel_picker/cplay_neopixel_picker.ino
@@ -30,6 +30,10 @@
 #include "Adafruit_BluefruitLE_UART.h"
 #include "BluefruitConfig.h"
 
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
 #include <Adafruit_CircuitPlayground.h>
 
 // Configuration (you don't need to change these, but can!):

--- a/examples/eddystone/eddystone.ino
+++ b/examples/eddystone/eddystone.ino
@@ -14,16 +14,16 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 #include "Adafruit_BLEEddystone.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/factoryreset/factoryreset.ino
+++ b/examples/factoryreset/factoryreset.ino
@@ -14,15 +14,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 // Create the bluefruit object, either software serial...uncomment these lines
 /*

--- a/examples/feathertester/feathertester.ino
+++ b/examples/feathertester/feathertester.ino
@@ -9,18 +9,13 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
-#if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)
-  // Required for Serial on Zero based boards
-  #define Serial SERIAL_PORT_USBVIRTUAL
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 Adafruit_BluefruitLE_SPI ble(BLUEFRUIT_SPI_CS, BLUEFRUIT_SPI_IRQ, BLUEFRUIT_SPI_RST);
 

--- a/examples/healththermometer/healththermometer.ino
+++ b/examples/healththermometer/healththermometer.ino
@@ -19,18 +19,18 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 #include "Adafruit_BLEGatt.h"
+#include "IEEE11073float.h"
 
 #include "BluefruitConfig.h"
 
-#include "IEEE11073float.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
 
 // Create the bluefruit object, either software serial...uncomment these lines
 /*

--- a/examples/heartratemonitor/heartratemonitor.ino
+++ b/examples/heartratemonitor/heartratemonitor.ino
@@ -19,15 +19,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 // Create the bluefruit object, either software serial...uncomment these lines
 /*

--- a/examples/hidcontrolkey/hidcontrolkey.ino
+++ b/examples/hidcontrolkey/hidcontrolkey.ino
@@ -34,16 +34,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined(ARDUINO_ARCH_SAMD)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
 
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/hidkeyboard/hidkeyboard.ino
+++ b/examples/hidkeyboard/hidkeyboard.ino
@@ -19,15 +19,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined(ARDUINO_ARCH_SAMD)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/hidmouse/hidmouse.ino
+++ b/examples/hidmouse/hidmouse.ino
@@ -22,15 +22,15 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined(ARDUINO_ARCH_SAMD)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 
 #include "BluefruitConfig.h"
+
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/midi/midi.ino
+++ b/examples/midi/midi.ino
@@ -1,14 +1,12 @@
 #include <Arduino.h>
 #include <SPI.h>
-
-// You may or may not need to include this depending on your platform
-// Include this for the 32u4, exclude it for the M0 for example
-//#include <SoftwareSerial.h>
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
 #include "Adafruit_BLEMIDI.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 #include "BluefruitConfig.h"
 

--- a/examples/ndof_bno055/ndof_bno055.ino
+++ b/examples/ndof_bno055/ndof_bno055.ino
@@ -14,11 +14,6 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-
-#if not defined (_VARIANT_ARDUINO_DUE_X_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include <Wire.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_BNO055.h>
@@ -27,6 +22,10 @@
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
 #include "BluefruitConfig.h"
 
 // Create the bluefruit object, either software serial...uncomment these lines

--- a/examples/neopixel_picker/neopixel_picker.ino
+++ b/examples/neopixel_picker/neopixel_picker.ino
@@ -15,17 +15,16 @@
 #include <string.h>
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
+#include <Adafruit_NeoPixel.h>
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 #include "BluefruitConfig.h"
 
-#include <Adafruit_NeoPixel.h>
 
 /*=========================================================================
     APPLICATION SETTINGS

--- a/examples/nvmdata/nvmdata.ino
+++ b/examples/nvmdata/nvmdata.ino
@@ -14,13 +14,12 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 #include "BluefruitConfig.h"
 

--- a/examples/throughput/throughput.ino
+++ b/examples/throughput/throughput.ino
@@ -14,13 +14,12 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 #include "BluefruitConfig.h"
 

--- a/examples/uribeacon/uribeacon.ino
+++ b/examples/uribeacon/uribeacon.ino
@@ -14,13 +14,12 @@
 
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
-  #include <SoftwareSerial.h>
-#endif
-
 #include "Adafruit_BLE.h"
 #include "Adafruit_BluefruitLE_SPI.h"
 #include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
 
 #include "BluefruitConfig.h"
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BluefruitLE nRF51
-version=1.9.3
+version=1.9.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for nRF51822-based Adafruit Bluefruit LE modules

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BluefruitLE nRF51
-version=1.9.4
+version=1.9.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for nRF51822-based Adafruit Bluefruit LE modules


### PR DESCRIPTION
To better facilitate C++/OO I've updated the Adafruit_BluefruitLE_nRF51 libraries for my personal use to include a context pointer (void*) that is passed in all callback methods. This is similar to the POSIX pthread_create method.

This allows for a more OO style handling of callbacks. Example:

_Somewhere, in a setup method far, far, away._
ble.setCallbackContext(this);
ble.setConnectCallback(SomeClass::connect);
ble.setDisconnectCallback(SomeClass::disconnect);

SomeClass.h
// class definition
public:
	static void connect(void* context) {
		((SomeClass*)context)->deviceConnected();
	}

	static void disconnect(void* context) {
		((SomeClass*)context)->deviceDisconnected();
	}
// class definition

SomeClass.cpp
       void SomeClass::deviceConnected() {
           // do something
       }
      
       void SomeClass::deviceDisconnected() {
           // do something
       }

I've effectively modified all the call back function to support this behavior while still maintaining the original API for backward compatibility while the old API is deprecated and removed, should you choose.

I've also marked the deprecated methods as @deprecated in the doxygen comments. Furthermore, I split up the responsibilities of registering a GATT callback function pointer and the GATT events to get call backs for. To do this I've added the following:

ble.enableBleGattCallback(chars_idx);
ble.disableBleGattCallback(chars_idx);

I have only tested the connect and disconnect callbacks. I'm testing the UART soon. It does compile though.

Thanks for all the help and dedication for the API, it's much appreciated. The least I could do is give back a little.

