### PR TITLE
Check for an error while reading NVM

### DIFF
--- a/Adafruit_BLE.cpp
+++ b/Adafruit_BLE.cpp
@@ -463,7 +463,10 @@ bool Adafruit_BLE::readNVM(uint16_t offset, uint8_t data[], uint16_t size)
   print(',');
   println(size);
 
-  readraw(); // readraw swallow OK/ERROR already
+  uint16_t len = readraw(); // readraw swallow OK/ERROR already
+
+  // Check for an error reading
+  if ( len != size ) return false;
 
   // skip if NULL is entered
   if (data) memcpy(data, this->buffer, min(size, BLE_BUFSIZE));


### PR DESCRIPTION
Occasionally the nRF51 module becomes unresponsive.

In this case the readNVM was happily returning a bunch of 0s,
when in reality it was not getting any bytes.

This change just makes sure the number of bytes returned by readraw matches what is expected.
