### PR TITLE
Fix some issues revealed by integration with StandardFirmataBLE

### DIFF
--- a/Adafruit_BluefruitLE_SPI.cpp
+++ b/Adafruit_BluefruitLE_SPI.cpp
@@ -210,6 +210,10 @@ bool Adafruit_BluefruitLE_SPI::setMode(uint8_t new_mode)
   // --> does not switch using +++ command
   _mode = new_mode;
 
+  // If we're entering DATA mode, flush any old response, so that it isn't
+  // interpreted as incoming UART data
+  if (_mode == BLUEFRUIT_MODE_DATA) flush();
+
   return true;
 }
 
@@ -235,8 +239,10 @@ bool Adafruit_BluefruitLE_SPI::sendInitializePattern(void)
 /******************************************************************************/
 bool Adafruit_BluefruitLE_SPI::sendPacket(uint16_t command, const uint8_t* buf, uint8_t count, uint8_t more_data)
 {
-  // flush old response before sending the new command
-  if (more_data == 0) flush();
+  // flush old response before sending the new command, but only if we're *not*
+  // in DATA mode, as the RX FIFO may containg incoming UART data that hasn't
+  // been read yet
+  if (more_data == 0 && _mode != BLUEFRUIT_MODE_DATA) flush();
 
   sdepMsgCommand_t msgCmd;
 

--- a/Adafruit_BluefruitLE_SPI.h
+++ b/Adafruit_BluefruitLE_SPI.h
@@ -71,6 +71,8 @@ class Adafruit_BluefruitLE_SPI : public Adafruit_BLE
     uint8_t         m_rx_buffer[BLE_BUFSIZE];
     Adafruit_FIFO   m_rx_fifo;
 
+    bool            m_mode_switch_command_enabled;
+
     // Low level transportation I/O functions
     bool    sendInitializePattern(void);
     bool    sendPacket(uint16_t command, const uint8_t* buffer, uint8_t count, uint8_t more_data);
@@ -93,6 +95,7 @@ class Adafruit_BluefruitLE_SPI : public Adafruit_BLE
     void end(void);
 
     bool setMode(uint8_t new_mode);
+    void enableModeSwitchCommand(bool enabled);
 
     // Class Print virtual function Interface
     virtual size_t write(uint8_t c);


### PR DESCRIPTION
I've been working on adding support for the Feather M0 Bluefruit LE to [StandardFirmataBLE](https://github.com/firmata/arduino/tree/master/examples/StandardFirmataBLE).  While doing so, I discovered a few issues, which are addressed by this pull request.  The changes here affect only the Adafruit_BluefruitLE_SPI class.

First, when alternating between reads and writes in DATA mode, it was possible to lose received data that hadn't yet been read.  For example, I was testing a scenario where the Firmata client (a Mac desktop) sent 6 bytes to the Feather.  After reading the first 3 bytes, the Firmata library wrote a response.  However, because Adafruit_BluefruitLE_SPI::sendPacket always empties the RX FIFO when more_data is 0, the last 3 bytes were lost.  I've changed it so that the FIFO is emptied only when *not* in DATA mode.  Also, I modified Adafruit_BluefruitLE_SPI::setMode to empty the RX FIFO when entering DATA mode, so that a previous command response isn't interpreted as incoming UART data.

Second, I was nervous about Adafruit_BluefruitLE_SPI's simulated handling of the "+++" command.  Since Firmata is a binary protocol, it's possible that that sequence of bytes could be sent to the client, which would then trigger an unexpected switch to command mode and break everything.  To eliminate this possibility, I added a method to disable the simulated "+++" handling.  It's still enabled by default, so the behavior of existing code won't change.