### PR TITLE
Port the neopixel sketch from the nRF52 library

### DIFF
--- a/examples/neopixel/BluefruitConfig.h
+++ b/examples/neopixel/BluefruitConfig.h
@@ -1,0 +1,57 @@
+// COMMON SETTINGS
+// ----------------------------------------------------------------------------------------------
+// These settings are used in both SW UART, HW UART and SPI mode
+// ----------------------------------------------------------------------------------------------
+#define BUFSIZE                        128   // Size of the read buffer for incoming data
+#define VERBOSE_MODE                   true  // If set to 'true' enables debug output
+#define BLE_READPACKET_TIMEOUT         500   // Timeout in ms waiting to read a response
+
+
+// SOFTWARE UART SETTINGS
+// ----------------------------------------------------------------------------------------------
+// The following macros declare the pins that will be used for 'SW' serial.
+// You should use this option if you are connecting the UART Friend to an UNO
+// ----------------------------------------------------------------------------------------------
+#define BLUEFRUIT_SWUART_RXD_PIN       9    // Required for software serial!
+#define BLUEFRUIT_SWUART_TXD_PIN       10   // Required for software serial!
+#define BLUEFRUIT_UART_CTS_PIN         11   // Required for software serial!
+#define BLUEFRUIT_UART_RTS_PIN         -1   // Optional, set to -1 if unused
+
+
+// HARDWARE UART SETTINGS
+// ----------------------------------------------------------------------------------------------
+// The following macros declare the HW serial port you are using. Uncomment
+// this line if you are connecting the BLE to Leonardo/Micro or Flora
+// ----------------------------------------------------------------------------------------------
+#ifdef Serial1    // this makes it not complain on compilation if there's no Serial1
+  #define BLUEFRUIT_HWSERIAL_NAME      Serial1
+#endif
+
+
+// SHARED UART SETTINGS
+// ----------------------------------------------------------------------------------------------
+// The following sets the optional Mode pin, its recommended but not required
+// ----------------------------------------------------------------------------------------------
+#define BLUEFRUIT_UART_MODE_PIN        12    // Set to -1 if unused
+
+
+// SHARED SPI SETTINGS
+// ----------------------------------------------------------------------------------------------
+// The following macros declare the pins to use for HW and SW SPI communication.
+// SCK, MISO and MOSI should be connected to the HW SPI pins on the Uno when
+// using HW SPI.  This should be used with nRF51822 based Bluefruit LE modules
+// that use SPI (Bluefruit LE SPI Friend).
+// ----------------------------------------------------------------------------------------------
+#define BLUEFRUIT_SPI_CS               8
+#define BLUEFRUIT_SPI_IRQ              7
+#define BLUEFRUIT_SPI_RST              4    // Optional but recommended, set to -1 if unused
+
+// SOFTWARE SPI SETTINGS
+// ----------------------------------------------------------------------------------------------
+// The following macros declare the pins to use for SW SPI communication.
+// This should be used with nRF51822 based Bluefruit LE modules that use SPI
+// (Bluefruit LE SPI Friend).
+// ----------------------------------------------------------------------------------------------
+#define BLUEFRUIT_SPI_SCK              13
+#define BLUEFRUIT_SPI_MISO             12
+#define BLUEFRUIT_SPI_MOSI             11

--- a/examples/neopixel/neopixel.ino
+++ b/examples/neopixel/neopixel.ino
@@ -1,0 +1,375 @@
+/*********************************************************************
+ This is an example for our nRF51 based Bluefruit LE modules
+
+ Pick one up today in the adafruit shop!
+
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+// This sketch is intended to be used with the NeoPixel control
+// surface in Adafruit's Bluefruit LE Connect mobile application.
+//
+// - Compile and flash this sketch to a board connected to/bundled with a nRF51
+// - Open the Bluefruit LE Connect app
+// - Switch to the NeoPixel utility
+// - Click the 'connect' button to establish a connection and
+//   send the meta-data about the pixel layout
+// - Use the NeoPixel utility to update the pixels on your device
+
+/* NOTE: This sketch required at least version 1.1.0 of Adafruit_Neopixel !!! */
+
+#include <string.h>
+#include <Arduino.h>
+#include <SPI.h>
+#include <Adafruit_NeoPixel.h>
+#include "Adafruit_BLE.h"
+#include "Adafruit_BluefruitLE_SPI.h"
+#include "Adafruit_BluefruitLE_UART.h"
+#if SOFTWARE_SERIAL_AVAILABLE
+  #include <SoftwareSerial.h>
+#endif
+
+#include "BluefruitConfig.h"
+
+#define FACTORYRESET_ENABLE     1
+#define NEOPIXEL_VERSION_STRING "Neopixel v2.0"
+#define PIN                     6   /* Pin used to drive the NeoPixels */
+
+#define MAXCOMPONENTS  4
+uint8_t *pixelBuffer = NULL;
+uint8_t width = 0;
+uint8_t height = 0;
+uint8_t stride;
+uint8_t componentsValue;
+bool is400Hz;
+uint8_t components = 3;     // only 3 and 4 are valid values
+
+Adafruit_NeoPixel neopixel = Adafruit_NeoPixel();
+
+// Create the bluefruit object, either software serial...uncomment these lines
+/*
+SoftwareSerial bluefruitSS = SoftwareSerial(BLUEFRUIT_SWUART_TXD_PIN, BLUEFRUIT_SWUART_RXD_PIN);
+
+Adafruit_BluefruitLE_UART ble(bluefruitSS, BLUEFRUIT_UART_MODE_PIN,
+                      BLUEFRUIT_UART_CTS_PIN, BLUEFRUIT_UART_RTS_PIN);
+*/
+
+/* ...or hardware serial, which does not need the RTS/CTS pins. Uncomment this line */
+// Adafruit_BluefruitLE_UART ble(BLUEFRUIT_HWSERIAL_NAME, BLUEFRUIT_UART_MODE_PIN);
+
+/* ...hardware SPI, using SCK/MOSI/MISO hardware SPI pins and then user selected CS/IRQ/RST */
+Adafruit_BluefruitLE_SPI ble(BLUEFRUIT_SPI_CS, BLUEFRUIT_SPI_IRQ, BLUEFRUIT_SPI_RST);
+
+/* ...software SPI, using SCK/MOSI/MISO user-defined SPI pins and then user selected CS/IRQ/RST */
+//Adafruit_BluefruitLE_SPI ble(BLUEFRUIT_SPI_SCK, BLUEFRUIT_SPI_MISO,
+//                             BLUEFRUIT_SPI_MOSI, BLUEFRUIT_SPI_CS,
+//                             BLUEFRUIT_SPI_IRQ, BLUEFRUIT_SPI_RST);
+
+
+// A small helper
+void error(const __FlashStringHelper*err) {
+  Serial.println(err);
+  while (1);
+}
+
+void serial_printf(const char * format, ...) {
+  char buffer [48];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  va_end(args);
+  Serial.print(buffer);
+}
+
+
+/**************************************************************************/
+/*!
+    @brief  Sets up the HW an the BLE module (this function is called
+            automatically on startup)
+*/
+/**************************************************************************/
+void setup(void)
+{
+  Serial.begin(115200);
+  Serial.println("Adafruit Bluefruit Neopixel Test");
+  Serial.println("--------------------------------");
+
+  Serial.println();
+  Serial.println("Please connect using the Bluefruit Connect LE application");
+
+  // Config Neopixels
+  neopixel.begin();
+
+  /* Initialise the module */
+  Serial.print(F("Initialising the Bluefruit LE module: "));
+
+  if ( !ble.begin(VERBOSE_MODE) )
+  {
+    error(F("Couldn't find Bluefruit, make sure it's in CoMmanD mode & check wiring?"));
+  }
+  Serial.println( F("OK!") );
+
+  if ( FACTORYRESET_ENABLE )
+  {
+    /* Perform a factory reset to make sure everything is in a known state */
+    Serial.println(F("Performing a factory reset: "));
+    if ( ! ble.factoryReset() ){
+      error(F("Couldn't factory reset"));
+    }
+  }
+
+  /* Disable command echo from Bluefruit */
+  ble.echo(false);
+
+  ble.verbose(false);  // debug info is a little annoying after this point!
+
+    /* Wait for connection */
+  while (! ble.isConnected()) {
+      delay(500);
+  }
+
+  Serial.println(F("***********************"));
+
+  // Set Bluefruit to DATA mode
+  Serial.println( F("Switching to DATA mode!") );
+  ble.setMode(BLUEFRUIT_MODE_DATA);
+
+  Serial.println(F("***********************"));
+
+}
+
+void loop()
+{
+  // Echo received data
+  if ( ble.isConnected() )
+  {
+    int command = ble.read();
+
+    switch (command) {
+      case 'V': {   // Get Version
+          commandVersion();
+          break;
+        }
+  
+      case 'S': {   // Setup dimensions, components, stride...
+          commandSetup();
+          break;
+       }
+
+      case 'C': {   // Clear with color
+          commandClearColor();
+          break;
+      }
+
+      case 'B': {   // Set Brightness
+          commandSetBrightness();
+          break;
+      }
+            
+      case 'P': {   // Set Pixel
+          commandSetPixel();
+          break;
+      }
+  
+      case 'I': {   // Receive new image
+          commandImage();
+          break;
+       }
+
+    }
+  }
+}
+
+void swapBuffers()
+{
+  uint8_t *base_addr = pixelBuffer;
+  int pixelIndex = 0;
+  for (int j = 0; j < height; j++)
+  {
+    for (int i = 0; i < width; i++) {
+      if (components == 3) {
+        neopixel.setPixelColor(pixelIndex, neopixel.Color(*base_addr, *(base_addr+1), *(base_addr+2)));
+      }
+      else {
+        neopixel.setPixelColor(pixelIndex, neopixel.Color(*base_addr, *(base_addr+1), *(base_addr+2), *(base_addr+3) ));
+      }
+      base_addr+=components;
+      pixelIndex++;
+    }
+    pixelIndex += stride - width;   // Move pixelIndex to the next row (take into account the stride)
+  }
+  neopixel.show();
+
+}
+
+void commandVersion() {
+  Serial.println(F("Command: Version check"));
+  sendResponse(NEOPIXEL_VERSION_STRING);
+}
+
+void commandSetup() {
+  Serial.println(F("Command: Setup"));
+
+  width = ble.read();
+  height = ble.read();
+  stride = ble.read();
+  componentsValue = ble.read();
+  is400Hz = ble.read();
+
+  neoPixelType pixelType;
+  pixelType = componentsValue + (is400Hz ? NEO_KHZ400 : NEO_KHZ800);
+
+  components = (componentsValue == NEO_RGB || componentsValue == NEO_RBG || componentsValue == NEO_GRB || componentsValue == NEO_GBR || componentsValue == NEO_BRG || componentsValue == NEO_BGR) ? 3:4;
+
+  serial_printf("\tsize: %dx%d\n", width, height);
+  serial_printf("\tstride: %d\n", stride);
+  serial_printf("\tpixelType %d\n", pixelType);
+  serial_printf("\tcomponents: %d\n", components);
+
+  if (pixelBuffer != NULL) {
+      delete[] pixelBuffer;
+  }
+
+  uint32_t size = width*height;
+  pixelBuffer = new uint8_t[size*components];
+  neopixel.updateLength(size);
+  neopixel.updateType(pixelType);
+  neopixel.setPin(PIN);
+
+  // Done
+  sendResponse("OK");
+}
+
+void commandSetBrightness() {
+  Serial.println(F("Command: SetBrightness"));
+
+   // Read value
+  uint8_t brightness = ble.read();
+
+  // Set brightness
+  neopixel.setBrightness(brightness);
+
+  // Refresh pixels
+  swapBuffers();
+
+  // Done
+  sendResponse("OK");
+}
+
+void commandClearColor() {
+  Serial.println(F("Command: ClearColor"));
+
+  // Read color
+  uint8_t color[MAXCOMPONENTS];
+  for (int j = 0; j < components;) {
+    if (ble.available()) {
+      color[j] = ble.read();
+      j++;
+    }
+  }
+
+  // Set all leds to color
+  int size = width * height;
+  uint8_t *base_addr = pixelBuffer;
+  for (int i = 0; i < size; i++) {
+    for (int j = 0; j < components; j++) {
+      *base_addr = color[j];
+      base_addr++;
+    }
+  }
+
+  // Swap buffers
+  Serial.println(F("ClearColor completed"));
+  swapBuffers();
+
+
+  if (components == 3) {
+    serial_printf("\tclear (%d, %d, %d)\n", color[0], color[1], color[2] );
+  }
+  else {
+    serial_printf("\tclear (%d, %d, %d, %d)\n", color[0], color[1], color[2], color[3] );
+  }
+  
+  // Done
+  sendResponse("OK");
+}
+
+void commandSetPixel() {
+  Serial.println(F("Command: SetPixel"));
+
+  // Read position
+  uint8_t x = ble.read();
+  uint8_t y = ble.read();
+
+  // Read colors
+  uint32_t pixelOffset = y*width+x;
+  uint32_t pixelDataOffset = pixelOffset*components;
+  uint8_t *base_addr = pixelBuffer+pixelDataOffset;
+  for (int j = 0; j < components;) {
+    if (ble.available()) {
+      *base_addr = ble.read();
+      base_addr++;
+      j++;
+    }
+  }
+
+  // Set colors
+  uint32_t neopixelIndex = y*stride+x;
+  uint8_t *pixelBufferPointer = pixelBuffer + pixelDataOffset;
+  uint32_t color;
+  if (components == 3) {
+    color = neopixel.Color( *pixelBufferPointer, *(pixelBufferPointer+1), *(pixelBufferPointer+2) );
+    serial_printf("\tcolor (%d, %d, %d)\n",*pixelBufferPointer, *(pixelBufferPointer+1), *(pixelBufferPointer+2) );
+  }
+  else {
+    color = neopixel.Color( *pixelBufferPointer, *(pixelBufferPointer+1), *(pixelBufferPointer+2), *(pixelBufferPointer+3) );
+    serial_printf("\tcolor (%d, %d, %d, %d)\n", *pixelBufferPointer, *(pixelBufferPointer+1), *(pixelBufferPointer+2), *(pixelBufferPointer+3) );    
+  }
+  neopixel.setPixelColor(neopixelIndex, color);
+  neopixel.show();
+
+  // Done
+  sendResponse("OK");
+}
+
+void commandImage() {
+  serial_printf("Command: Image %dx%d, %d, %d\n", width, height, components, stride);
+  
+  // Receive new pixel buffer
+  int size = width * height;
+  uint8_t *base_addr = pixelBuffer;
+  for (int i = 0; i < size; i++) {
+    for (int j = 0; j < components;) {
+      if (ble.available()) {
+        *base_addr = ble.read();
+        base_addr++;
+        j++;
+      }
+    }
+
+/*
+    if (components == 3) {
+      uint32_t index = i*components;
+      Serial.printf("\tp%d (%d, %d, %d)\n", i, pixelBuffer[index], pixelBuffer[index+1], pixelBuffer[index+2] );
+    }
+    */
+  }
+
+  // Swap buffers
+  Serial.println(F("Image received"));
+  swapBuffers();
+
+  // Done
+  sendResponse("OK");
+}
+
+void sendResponse(char const *response) {
+    serial_printf("Send Response: %s\n", response);
+    ble.write(response, strlen(response)*sizeof(char));
+}


### PR DESCRIPTION
This is a port of the neopixel sketch in existing in the nRF52 library

No files where modified, only the sketch example was added

I do not have a large selection of chips, so this was only tested on a:
Adafruit Feather 32u4 Bluefruit LE connected to a Adafruit NeoPixel FeatherWing

There is a spot in the code for sending an image, but the Android app doesn't have support for it (or I just couldn't find it). Although, other then the bluetooth connection, very little was changed.